### PR TITLE
RAC-6220 implement session for poller APIs

### DIFF
--- a/ThreadingTimer.py
+++ b/ThreadingTimer.py
@@ -1,0 +1,22 @@
+import threading
+import time
+import flask
+
+
+class ThreadingTimer(object):
+    def __init__(self, app, interval=60):
+        self.interval = interval
+        self.app = app
+        thread = threading.Thread(target=self.run, args=())
+        thread.daemon = True
+        thread.start()
+
+    def run(self):
+        while True:
+            with self.app.app.app_context():
+                handlers = flask.current_app.config.get('handlers', {})
+                for host, data in handlers.iteritems():
+                    if data and time.time() - data['timestamp'] >= self.interval:
+                        data['handle'].logout()
+                        handlers[host] = None
+            time.sleep(5)

--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@
 
 import connexion
 import json
+import ThreadingTimer
 
 if __name__ == '__main__':
 
@@ -33,6 +34,7 @@ if __name__ == '__main__':
 
     app = connexion.App(__name__, specification_dir='./swagger/')
     app.add_api('swagger.yaml', arguments={'title': 'UCS Service'})
+    ThreadingTimer.ThreadingTimer(app)
     app.run(host=config['address'],
             port=config['port'],
             debug=config['debug'],


### PR DESCRIPTION
**Background**
----

Currently UCS poller mechanism will fail with large quantity of pollers (like 150 pollers). The reason is that login process is slow when we talked with UCSM(in ucspe, we haven't test with UCS physically) via ucs-service and every poller api needs to login.
[https://rackhd.atlassian.net/browse/RAC-6220](https://rackhd.atlassian.net/browse/RAC-6220)

**AC**:
- Code updated and merged
- Unit test added

**Detail**
----
Created a thread(timer), to keep the login object(UCSHandler), if timer timeout, release login object and next poller need to login again

@iceiilin @anhou @pengz1 @bbcyyb