### PR TITLE
 Change taskId to callbackId

### DIFF
--- a/controllers/ucs_async_controller.py
+++ b/controllers/ucs_async_controller.py
@@ -8,11 +8,11 @@ from util.util import serialize_ucs_http_headers
 
 @response_wrapper
 @status_handler(default_status=202)
-def getPollersAsync(identifier, classIds, taskId):
+def getPollersAsync(identifier, classIds, callbackId):
     """Get pollers asynchronously"""
     tasks.runUcsJob.delay(
         "getPollers",
-        taskId,
+        callbackId,
         serialize_ucs_http_headers(request.headers),
         identifier,
         classIds

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -190,9 +190,9 @@ paths:
         description: "UCS manager user password"
         required: true
         type: "string"
-      - name: "taskId"
+      - name: "callbackId"
         in: "query"
-        description: "UCS manager user password"
+        description: "Callback API identity"
         required: true
         type: "string"
       - name: "identifier"

--- a/tasks.py
+++ b/tasks.py
@@ -34,23 +34,23 @@ def _runUcsJobCore(funcName, *args, **kwargs):
 
 
 @app.task
-def runUcsJob(funcName, taskId, *args, **kwargs):
+def runUcsJob(funcName, callbackId, *args, **kwargs):
     """
     Run Ucs service job with given job name and arguments,
     and initiate RackHD callback task with returned job result
     """
     kwargs["handlers"] = handlers
     result = _runUcsJobCore(funcName, *args, **kwargs)
-    sendHttpRequest.delay(taskId, result)
+    sendHttpRequest.delay(callbackId, result)
 
 
 @app.task
-def sendHttpRequest(taskId, data):
+def sendHttpRequest(callbackId, data):
     """
     Post data to RackHD via callbackUrl
     """
     url = callbackUrl
-    query_string = {"taskId": taskId}
+    query_string = {"callbackId": callbackId}
     headers = {'content-type': "application/json"}
     res = requests.request(
         "POST", url, json={"body": data[0]}, headers=headers, params=query_string

--- a/tests/controllers_tests/test_ucs_async_controller.py
+++ b/tests/controllers_tests/test_ucs_async_controller.py
@@ -13,7 +13,7 @@ MOCK_HEADER = {
     'ucs-user': USER
 }
 MOCK_CLASS_IDS = ['processorEnvStats', 'memoryUnitEnvStats']
-MOCK_TASK_ID = "12345"
+MOCK_CALLBACK_ID = "12345"
 MOCK_ID = "abc"
 
 
@@ -31,10 +31,10 @@ class test_default_async_controller(unittest.TestCase):
         """Get pollers asynchronously"""
         mock_tasks.delay.return_value = True
         mock_request.headers = MOCK_HEADER
-        result = controler.getPollersAsync(MOCK_ID, MOCK_CLASS_IDS, MOCK_TASK_ID)
+        result = controler.getPollersAsync(MOCK_ID, MOCK_CLASS_IDS, MOCK_CALLBACK_ID)
         mock_tasks.delay.assert_called_once_with(
             "getPollers",
-            MOCK_TASK_ID,
+            MOCK_CALLBACK_ID,
             MOCK_HEADER,
             MOCK_ID,
             MOCK_CLASS_IDS

--- a/tests/tasks_tests/test_tasks.py
+++ b/tests/tasks_tests/test_tasks.py
@@ -4,7 +4,7 @@ import unittest
 import mock
 import tasks
 
-MOCK_TASK_ID = "task_id"
+MOCK_CALLBACK_ID = "callback_id"
 MOCK_POLLER_DATA = {"data": "mock_poller_data"}
 MOCK_ARGS = ("arg1", "arg2")
 MOCK_KWARGS = {"arg3": "arg3"}
@@ -29,13 +29,13 @@ class test_default_tasks(unittest.TestCase):
     def testSentHttpRequest(self, mock_celery, mock_request):
         """Test sendHttpRequest task"""
         mock_request.return_value = self.mockRequestResponse()
-        tasks.sendHttpRequest(MOCK_TASK_ID, (MOCK_POLLER_DATA["data"], 200))
+        tasks.sendHttpRequest(MOCK_CALLBACK_ID, (MOCK_POLLER_DATA["data"], 200))
         mock_request.assert_called_once_with(
             "POST",
             tasks.callbackUrl,
             json={"body": MOCK_POLLER_DATA["data"]},
             headers={'content-type': 'application/json'},
-            params={"taskId": MOCK_TASK_ID}
+            params={"callbackId": MOCK_CALLBACK_ID}
         )
 
     @mock.patch('tasks.sendHttpRequest')
@@ -45,11 +45,11 @@ class test_default_tasks(unittest.TestCase):
         """Test runUcsJob task"""
         mock_ucs_get_pollers.return_value = MOCK_POLLER_DATA
         mock_send_http_request.delay.return_value = "test"
-        tasks.runUcsJob("getPollers", MOCK_TASK_ID, *MOCK_ARGS, **MOCK_KWARGS)
+        tasks.runUcsJob("getPollers", MOCK_CALLBACK_ID, *MOCK_ARGS, **MOCK_KWARGS)
         kwargs_with_handler = {"handlers": {}}
         kwargs_with_handler.update(MOCK_KWARGS)
         mock_ucs_get_pollers.assert_called_once_with(*MOCK_ARGS, **kwargs_with_handler)
         mock_send_http_request.delay.assert_called_once_with(
-            MOCK_TASK_ID,
+            MOCK_CALLBACK_ID,
             (MOCK_POLLER_DATA["data"], 200)
         )


### PR DESCRIPTION
Background:
It is found taskId will lead to data mess for pollers belongs to the same task. We need a new kind of ID to identify different data.

Details:
Change all related "taskId" to "callbackId" in unittest, task.py, ucs_async_controller.py 