### PR TITLE
[RAC-6404] fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,16 @@
-FROM python:2
+# Copyright 2017, Dell EMC, Inc.
+FROM ubuntu:16.04
 WORKDIR /usr/src/app
-COPY requirements.txt ./
-RUN pip install -r requirements.txt
+RUN apt-get update && \
+    apt-get install -y \
+    python-pip \
+    python-dev \
+    libffi-dev \
+    libssl-dev \
+    rabbitmq-server
 COPY . .
+RUN pip install -U setuptools==36.7.2
+RUN pip install --upgrade pip
+RUN pip install -r requirements.txt
 EXPOSE 7080
-CMD [ "python", "./app.py" ]
+ENTRYPOINT sh docker-entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ To run unit tests:
 
     python -m unittest discover -s tests
 
+## Running in docker
+Ucs-service in docker shouldn't run in host mode, because rabbitmq service is built in docker and it may conflict with RackHD's rabbitmq server.
+
+    sudo docker -t example/ucs-service .
+    sudo docker run -p 7080:7080 -ti --rm example/ucs-service
+
 ## Licensing
 
 Licensed under the Apache License, Version 2.0 (the “License”); you may not use this file except in compliance with the License. You may obtain a copy of the License at http://www.apache.org/licenses/LICENSE-2.0

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Copyright 2017, Dell EMC, Inc.
+
+service rabbitmq-server start
+python app.py >> app.log &
+python tasks.py worker >> tasks.log

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,3 +1,4 @@
+; Copyright 2017, Dell EMC, Inc.
 ; run echo_supervisord_conf > supervisord.conf to generate sample config file
 [supervisord]
 logfile=%(ENV_LOGDIR)s/supervisord.log ; main log file; default $CWD/supervisord.log


### PR DESCRIPTION
**Background**
----
Dockerfile update is needed due to new ucs-service code
[https://rackhd.atlassian.net/browse/RAC-6404](https://rackhd.atlassian.net/browse/RAC-6404)

**Detail**
----
New Dockerfile created.
Using supervisord to start the ucs-service see docker-entrypoint.sh.
Changed supervisord.config to prevent supervisord from running as daemon

@pengz1 @bbcyyb @PengTian0 

