### PR TITLE
remove rabbitmq in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,7 @@ RUN apt-get update && \
     python-pip \
     python-dev \
     libffi-dev \
-    libssl-dev \
-    rabbitmq-server
+    libssl-dev
 COPY . .
 RUN pip install -U setuptools==36.7.2
 RUN pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -53,10 +53,11 @@ To run unit tests:
     python -m unittest discover -s tests
 
 ## Running in docker
-Ucs-service in docker shouldn't run in host mode, because rabbitmq service is built in docker and it may conflict with RackHD's rabbitmq server.
+RabbitMQ is not included in docker, user should install RabbitMQ separately.
+Because of ucs-service's callback mechanism, it needs to communicate with RackHD host, so ucs-service in docker should run in host mode.
 
     sudo docker build -t example/ucs-service .
-    sudo docker run -p 7080:7080 -ti --rm example/ucs-service
+    sudo docker run -p 7080:7080 -ti --net=host --rm example/ucs-service
 
 ## Licensing
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 # Copyright 2017, Dell EMC, Inc.
 
-service rabbitmq-server start
 python app.py >> app.log 2>&1 &
 python tasks.py worker >> tasks.log 2>&1


### PR DESCRIPTION
Remove rabbitmq in docker to run docker in host mode.
Because of ucs-service's call back mechanism, docker needs to be run in host mode in order to communicate with rackhd. So rabbitmq should be removed in docker, or it will conflict with rackhd's rabbitmq.

@PengTian0 @pengz1 