### PR TITLE
Add test cases for ucs service function test

### DIFF
--- a/service/ucs.py
+++ b/service/ucs.py
@@ -106,7 +106,6 @@ class Ucs:
 
     @staticmethod
     def getCatalog(headers, identifier=None, handlers=None):
-        authInfo = Ucs._getUcsAuthInfo(headers)
         data = []
 
         handle = Ucs._getHandler(headers, handlers)

--- a/swagger/swagger.yaml
+++ b/swagger/swagger.yaml
@@ -203,7 +203,7 @@ paths:
           type: "string"
       responses:
         200:
-          description: "Successful data fetch of catalogs by class id"
+          description: "Successful data fetch of pollers by class id"
       x-tags:
       - tag: "default"
   /pollers/async:

--- a/tests/function_tests/run_test.sh
+++ b/tests/function_tests/run_test.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-# Copyright 2017, Dell, Inc.
-
-# Copyright 2017, Dell, Inc.
+# Copyright 2017, Dell EMC, Inc.
 
 ucs_user=ucspe
 ucs_pass=ucspe

--- a/tests/function_tests/run_test.sh
+++ b/tests/function_tests/run_test.sh
@@ -24,7 +24,7 @@ fi
 
 virtualenv .venv
 source .venv/bin/activate
-sudo pip install -q -r requirements.txt
+pip install -q -r requirements.txt
 export UCSCONFIG="{\"ucs-host\": \"$1\", \"ucs-pass\": \"$ucs_pass\", \"ucs-user\": \"$ucs_user\"}"
 nosetests -v --with-nosedep test_ucs_api
 

--- a/tests/function_tests/run_test.sh
+++ b/tests/function_tests/run_test.sh
@@ -24,7 +24,7 @@ fi
 
 virtualenv .venv
 source .venv/bin/activate
-sudo pip install -r requirements.txt
+sudo pip install -q -r requirements.txt
 export UCSCONFIG="{\"ucs-host\": \"$1\", \"ucs-pass\": \"$ucs_pass\", \"ucs-user\": \"$ucs_user\"}"
 nosetests -v --with-nosedep test_ucs_api
 

--- a/tests/function_tests/run_test.sh
+++ b/tests/function_tests/run_test.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # Copyright 2017, Dell, Inc.
 
 ucs_user=ucspe

--- a/tests/function_tests/run_test.sh
+++ b/tests/function_tests/run_test.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 # Copyright 2017, Dell, Inc.
 
+# Copyright 2017, Dell, Inc.
+
 ucs_user=ucspe
 ucs_pass=ucspe
 

--- a/tests/function_tests/test_common.py
+++ b/tests/function_tests/test_common.py
@@ -41,13 +41,16 @@ else:
         UCS_SERVICE_CONFIG["port"]
     )
 
-def request(method, api, query=None, payload=None):
+def request(method, api, query=None, payload=None, headers=None):
     """
     Local HTTP/HTTPS request method
     """
-    headers = {"ucs-user": UCSM_USER,
-               "ucs-password": UCSM_PASS,
-               "ucs-host": UCSM_IP}
+    if not headers:
+        headers = {
+            "ucs-user": UCSM_USER,
+            "ucs-password": UCSM_PASS,
+            "ucs-host": UCSM_IP
+        }
     url = UCS_SERVICE_URI + api
     response = getattr(requests, method)(
         url=url,

--- a/tests/function_tests/test_common.py
+++ b/tests/function_tests/test_common.py
@@ -41,7 +41,6 @@ else:
         UCS_SERVICE_CONFIG["port"]
     )
 
-
 def request(method, api, query=None, payload=None):
     """
     Local HTTP/HTTPS request method

--- a/tests/function_tests/test_common.py
+++ b/tests/function_tests/test_common.py
@@ -41,6 +41,7 @@ else:
         UCS_SERVICE_CONFIG["port"]
     )
 
+
 def request(method, api, query=None, payload=None, headers=None):
     """
     Local HTTP/HTTPS request method

--- a/tests/function_tests/test_ucs_api.py
+++ b/tests/function_tests/test_ucs_api.py
@@ -160,7 +160,7 @@ class ucs_api(unittest.TestCase):
         """
         api_data = request("get", "/sys")
         self.assertEqual(api_data['status'], 200,
-                         'Incorrect HTTP return code, expected 202, got:' + str(api_data['status']))
+                         'Incorrect HTTP return code, expected 200, got:' + str(api_data['status']))
         total_elements = 0
         for device_type in api_data["json"]:
             for element in api_data["json"][str(device_type)]:

--- a/tests/function_tests/test_ucs_api.py
+++ b/tests/function_tests/test_ucs_api.py
@@ -153,6 +153,123 @@ class ucs_api(unittest.TestCase):
         # verify power state is up
         self.check_all_server_power_state("up")
 
+    def test_async_api_ucs_poller(self):
+        """
+        Test the /pollers/async ucs API
+        :return:
+        """
+        api_data = request("get", "/sys")
+        self.assertEqual(api_data['status'], 200,
+                         'Incorrect HTTP return code, expected 202, got:' + str(api_data['status']))
+        total_elements = 0
+        for device_type in api_data["json"]:
+            for element in api_data["json"][str(device_type)]:
+                api_data_c = request(
+                    "get", "/pollers/async",
+                    query={
+                        "identifier": element["relative_path"].strip("/"),
+                        "classIds": ["equipmentLed"],
+                        "callbackId": "abcd"
+                    }
+                )
+                self.assertEqual(api_data_c['status'], 202,
+                                 'Incorrect HTTP return code, expected 202, got:' +
+                                 str(api_data_c['status']))
+                self.assertEqual(api_data_c['json'], "Accepted",
+                                 "Incorret HTTP response body for asynchronous API")
+                total_elements += 1
+        self.assertGreater(total_elements, 0, "Zero pollers elements found")
+
+    def test_async_api_ucs_catalog(self):
+        """
+        Test the /pollers/async ucs API
+        :return:
+        """
+        api_data = request("get", "/sys")
+        self.assertEqual(api_data['status'], 200,
+                         'Incorrect HTTP return code, expected 200, got:' + str(api_data['status']))
+        total_elements = 0
+        for elementTypes in api_data["json"]:
+            for element in api_data["json"][str(elementTypes)]:
+                api_data_c = request("get", "/catalog/async",
+                                     query={"identifier": element["relative_path"].strip("/"),
+                                            "callbackId": "abcd"})
+                self.assertEqual(api_data_c['status'], 202,
+                                 'Incorrect HTTP return code, expected 202, got:' +
+                                 str(api_data_c['status']))
+                self.assertEqual(api_data_c['json'], "Accepted",
+                                 "Incorret HTTP response body for asynchronous API")
+                total_elements += 1
+        self.assertGreater(total_elements, 0, "Zero catalog elements found")
+
+
+@attr(all=True, negative=True)
+class ucs_api_negative(unittest.TestCase):
+
+    def test_api_without_full_headers(self):
+        """
+        Test the /sys ucs API without full headers
+        :return:
+        """
+        api_data = request("get", "/sys", headers={"ucs-host": "10.1.1.1"})
+        self.assertEqual(api_data['status'], 400,
+                         'Incorrect HTTP return code, expected 400, got:' + str(api_data['status']))
+
+    def test_async_api_ucs_poller(self):
+        """
+        Test the /pollers/async ucs API without callbackId
+        :return:
+        """
+        api_data_c = request("get", "/pollers/async", query={"identifier": "/sys/chassis-1",
+                                                             "classIds": ["equipmentLed"]})
+        self.assertEqual(api_data_c['status'], 400,
+                         'Incorrect HTTP return code, expected 400, got:' +
+                         str(api_data_c['status']))
+
+    def test_async_api_ucs_poller1(self):
+        """
+        Test the /pollers/async ucs API without classIds
+        :return:
+        """
+        api_data_c = request("get", "/pollers/async", query={"identifier": "/sys/chassis-1",
+                                                             "callbackId": "abc"})
+        self.assertEqual(api_data_c['status'], 400,
+                         'Incorrect HTTP return code, expected 400, got:' +
+                         str(api_data_c['status']))
+
+    def test_async_api_ucs_catalog(self):
+        """
+        Test the /catalog/async ucs API without callbackId
+        :return:
+        """
+        api_data_c = request("get", "/catalog/async", query={"identifier": "/sys/chassis-1"})
+        self.assertEqual(api_data_c['status'], 400,
+                         'Incorrect HTTP return code, expected 400, got:' +
+                         str(api_data_c['status']))
+
+
+@attr(all=True, robust=True)
+class ucs_api_stress(unittest.TestCase):
+
+    def test_async_api_ucs_catalog(self):
+        """
+        Stress test the /catalog/async ucs API
+        :return:
+        """
+        api_data = request("get", "/sys")
+        self.assertEqual(api_data['status'], 200,
+                         'Incorrect HTTP return code, expected 200, got:' + str(api_data['status']))
+        element = api_data["json"].values()[0][0]
+        for i in range(512):
+            api_data_c = request("get", "/catalog/async",
+                                 query={"identifier": element["relative_path"].strip("/"),
+                                        "callbackId": "abcd"})
+            self.assertEqual(api_data_c['status'], 202,
+                             'Incorrect HTTP return code, expected 202, got:' +
+                             str(api_data_c['status']))
+            self.assertEqual(api_data_c['json'], "Accepted",
+                             "Incorret HTTP response body for asynchronous API")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add more test cases for ucs-service function test:
1. Add test cases for new asynchronous API /catalog/async and /catalog/poller
2. Add some negative test cases
3. Add a stress test case.

@anhou @bbcyyb @HQebupt @mcgG 