### PR TITLE
Change all existing API to use session-keep feature

### DIFF
--- a/controllers/ucs_controller.py
+++ b/controllers/ucs_controller.py
@@ -12,13 +12,15 @@ def login_get():
 @response_wrapper
 @status_handler(default_status=200)
 def systemGetAll():
-    return Ucs.systemGetAll(request.headers)
+    handlers = current_app.config.get("handlers")
+    return Ucs.systemGetAll(request.headers, handlers=handlers)
 
 
 @response_wrapper
 @status_handler(default_status=200)
 def getRackmount():
-    return Ucs.getRackmount(request.headers)
+    handlers = current_app.config.get("handlers")
+    return Ucs.getRackmount(request.headers, handlers=handlers)
 
 
 @response_wrapper
@@ -33,32 +35,32 @@ def getCatalog(identifier=None):
 def getPollers(identifier, classIds):
     handlers = current_app.config.get("handlers")
     return Ucs.getPollers(
-        request.headers,
-        identifier,
-        classIds,
-        handlers=handlers
-    )
+        request.headers, identifier, classIds, handlers=handlers)
 
 
 @response_wrapper
 @status_handler(default_status=200)
 def getChassis():
-    return Ucs.getChassis(request.headers)
+    handlers = current_app.config.get("handlers")
+    return Ucs.getChassis(request.headers, handlers=handlers)
 
 
 @response_wrapper
 @status_handler(default_status=200)
 def getServiceProfile():
-    return Ucs.getServiceProfile(request.headers)
+    handlers = current_app.config.get("handlers")
+    return Ucs.getServiceProfile(request.headers, handlers=handlers)
 
 
 @response_wrapper
 @status_handler(default_status=200)
 def powerStatus(identifier=None):
-    return Ucs.powerStatus(request.headers, identifier)
+    handlers = current_app.config.get("handlers")
+    return Ucs.powerStatus(request.headers, identifier, handlers=handlers)
 
 
 @response_wrapper
 @status_handler(default_status=200)
 def powerMgmt(identifier=None, action=None, physical=False):
-    return Ucs.powerMgmt(request.headers, identifier, action, physical)
+    handlers = current_app.config.get("handlers")
+    return Ucs.powerMgmt(request.headers, identifier, action, physical, handlers=handlers)

--- a/service/ucs.py
+++ b/service/ucs.py
@@ -39,29 +39,25 @@ class Ucs:
             "humanReadableName": "Servers"
         }]
         finalObjs = {}
-        try:
-            for x in elements:
-                units = []
-                try:
-                    components = handle.query_children(
-                        in_dn="sys", class_id=x["ciscoXmlName"])
-                except UcsException as e:
-                    handle.logout()
-                    return {"error": e.error_descr}
+        for x in elements:
+            units = []
+            try:
+                components = handle.query_children(
+                    in_dn="sys", class_id=x["ciscoXmlName"])
+            except UcsException as e:
+                handle.logout()
+                return {"error": e.error_descr}
+            else:
+                if (type(components) == list):
+                    for y in components:
+                        subElement = {
+                            "relative_path": "/" + (vars(y))["dn"]
+                        }
+                        units.append(subElement)
+                    finalObjs[x["humanReadableName"]] = units
                 else:
-                    if (type(components) == list):
-                        for y in components:
-                            subElement = {
-                                "relative_path": "/" + (vars(y))["dn"]
-                            }
-                            units.append(subElement)
-                        finalObjs[x["humanReadableName"]] = units
-                    else:
-                        return {"error": "Couldn't fetch " + x["ciscoXmlName"]}
-            return {"data": finalObjs}
-        except UcsException as e:
-            handle.loout()
-            raise e
+                    return {"error": "Couldn't fetch " + x["ciscoXmlName"]}
+        return {"data": finalObjs}
 
     @staticmethod
     def getRackmount(headers, handlers=None):

--- a/util/decorator.py
+++ b/util/decorator.py
@@ -30,14 +30,17 @@ def status_handler(default_status=200):
             except Exception as e:
                 return 'Internal Server Error', traceback.format_exc(e), 500
 
-            if result.get("data"):
-                return result.get("data"), default_status
-            elif result.get("error") == "Forbidden":
-                return result.get("error"), "", 403
-            elif result.get("error"):
-                return result.get("error"), "", 500
+            if isinstance(result, dict):
+                if "data" in result.keys():
+                    return result.get("data"), default_status
+                elif result.get("error") == "Forbidden":
+                    return result.get("error"), "", 403
+                elif result.get("error"):
+                    return result.get("error"), "", 500
+                else:
+                    return "Unknown", "", 500
             else:
-                return "Unknown", "", 500
+                return result, "", default_status
 
         return wrapper
     return outter


### PR DESCRIPTION
### Background
New session keep feature is introduced in async UCS-service design. However legacy sync API is still using default session feature. We need to move all APIs to use session-keep feature.

### AC
1. Update **all legacy** ucs-service API to new session mode.
2. Keep current related unittest cases work well.

**reviewer**
@pengz1 @anhou @HQebupt @mcgG 